### PR TITLE
Added a new "ELDAT Easywave RX09 dongle" version.

### DIFF
--- a/cp210x.c
+++ b/cp210x.c
@@ -171,7 +171,8 @@ static const struct usb_device_id id_table[] = {
     { USB_DEVICE(0x12B8, 0xEC62) }, /* Link G4+ ECU */
     { USB_DEVICE(0x13AD, 0x9999) }, /* Baltech card reader */
     { USB_DEVICE(0x1555, 0x0004) }, /* Owen AC4 USB-RS485 Converter */
-    { USB_DEVICE(0x155A, 0x1006) },    /* ELDAT Easywave RX09 */
+    { USB_DEVICE(0x155A, 0x1005) },    /* ELDAT Easywave RX09 dongle */
+    { USB_DEVICE(0x155A, 0x1006) },    /* ELDAT Easywave RX09 dongle */
     { USB_DEVICE(0x166A, 0x0201) }, /* Clipsal 5500PACA C-Bus Pascal Automation Controller */
     { USB_DEVICE(0x166A, 0x0301) }, /* Clipsal 5800PC C-Bus Wireless PC Interface */
     { USB_DEVICE(0x166A, 0x0303) }, /* Clipsal 5500PCU C-Bus USB interface */


### PR DESCRIPTION
added
   { USB_DEVICE(0x155A, 0x1005) },    /* ELDAT Easywave RX09 dongle*/

There was already an "ELDAT Easywave RX09 dongle" present but this have PID_0x1006 and my dongle has PID_0x1005